### PR TITLE
Update ImmutableList for AM > 6.0 dependency

### DIFF
--- a/src/main/java/org/forgerock/openam/auth/nodes/ProfileAttributeDecisionNode.java
+++ b/src/main/java/org/forgerock/openam/auth/nodes/ProfileAttributeDecisionNode.java
@@ -19,7 +19,7 @@ package org.forgerock.openam.auth.nodes;
 
 import com.google.inject.assistedinject.Assisted;
 import com.sun.identity.shared.debug.Debug;
-import org.forgerock.guava.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 import org.forgerock.json.JsonValue;
 import org.forgerock.openam.annotations.sm.Attribute;
 import org.forgerock.openam.auth.node.api.*;
@@ -39,14 +39,8 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.ResourceBundle;
 import javax.inject.Inject;
-import org.forgerock.guava.common.collect.ImmutableList;
 import org.forgerock.json.JsonValue;
 import org.forgerock.util.i18n.PreferredLocales;
-
-
-
-
-
 
 
 @Node.Metadata(outcomeProvider = ProfileAttributeDecisionNode.OutcomeProvider.class,


### PR DESCRIPTION
ImmutableList cannot be resolved since _org.forgerock.guava.common.collect.ImmutableList_ dependency has been removed in 6.5. It's now replaced with _com.google.common.collect.ImmutableList_